### PR TITLE
Added complex manipulation ops and unit tests for added ops

### DIFF
--- a/mesh_tensorflow/ops.py
+++ b/mesh_tensorflow/ops.py
@@ -6644,7 +6644,7 @@ def split_complex(x, complex_dim=None):
     return output
   output = slicewise(
     tf_fn,
-    x,
+    [x],
     output_shape=x.shape.resize_dimension(split_dim.name, split_dim.size*2),
     output_dtype=tf.float32,
     splittable_dims=splittable_dims,

--- a/mesh_tensorflow/ops.py
+++ b/mesh_tensorflow/ops.py
@@ -6600,3 +6600,74 @@ def nth_largest_element(x, n, reduced_dim, name=None):
 
 def nth_smallest_element(x, n, reduced_dim, name=None):
   return -nth_largest_element(-x, n, reduced_dim, name=name)
+
+def to_complex(x, complex_dim=None):
+  """Gathers the real and imaginary of a tensor in a complex tensor
+
+  Args:
+    x: a float Tensor
+    complex_dim: a Dimension where both the real and imaginary parts of the
+      tensor are. Defaults to None, which corresponds to the last
+      dimension of the tensor.
+  Returns:
+    a Tensor, complex-valued
+  """
+  if complex_dim is None:
+    complex_dim = x.shape[-1]
+  x_real, x_imag = split(x, complex_dim, 2)
+  x_real = cast(x_real, tf.complex64)
+  x_imag = cast(x_imag, tf.complex64)
+  x_complex = x_real + 1j * x_imag
+  return x_complex
+
+def split_complex(x, complex_dim=None):
+  """Splits a complex tensor into real and imaginary, concatenated
+
+  Args:
+    x: a float Tensor
+    complex_dim: a Dimension where you want the split to happen.
+      Defaults to None, which corresponds to the last dimension of the tensor.
+  Returns:
+    a Tensor, float-valued
+  """
+  op = SplitComplexOperation(x, complex_dim=complex_dim)
+  output = op.outputs[0]
+  return output
+
+class SplitComplexOperation(Operation):
+  def __init__(self, split_input, complex_dim=None, name=None):
+    super().__init__([split_input], name=name or 'split_complex')
+    if complex_dim is None:
+        self._split_dim = split_input.shape.dims[-1]
+        self._split_axis = -1
+    else:
+        self._split_dim = complex_dim
+        self._split_axis = split_input.shape.index(complex_dim)
+    self._splittable_dims, self._unsplittable_dims = (
+      self._initialize_splittable_and_unsplittable_dims(
+        "splittable", [self._split_dim.name],
+      )
+    )
+    output_shape = split_input.shape.resize_dimension(
+      self._split_dim.name,
+      self._split_dim.size*2,
+    )
+    self._outputs = [Tensor(self, output_shape, tf.float32)]
+
+    def gradient(self, grad_ys):
+      dy = grad_ys[0]
+      dy_complex = to_complex(dy)
+      return [dy_complex]
+
+    def lower(self, lowering):
+      mesh_impl = lowering.mesh_impl(self)
+      split_input = self.inputs[0]
+      if mesh_impl.tensor_dimension_to_mesh_axis(self._split_dim) is not None:
+        raise ValueError("can't slice along complex split dimension")
+      def tf_fn(tf_input):
+        tf_real = tf.math.real(tf_input)
+        tf_imag = tf.math.imag(tf_input)
+        output = tf.concat([tf_real, tf_imag], axis=self._split_axis)
+        return output
+      y = mesh_impl.slicewise(tf_fn, lowering.tensors[split_input])
+      lowering.set_tensor_lowering(self.outputs[0], y)

--- a/mesh_tensorflow/ops_test.py
+++ b/mesh_tensorflow/ops_test.py
@@ -623,12 +623,12 @@ class RecomputeGradTest(tf.test.TestCase):
 
 
 class ComplexManipulationTest(tf.test.TestCase):
-  def setUP(self):
+  def setUp(self):
     super(ComplexManipulationTest, self).setUp()
     self.graph = mtf.Graph()
     self.mesh = mtf.Mesh(self.graph, "my_mesh")
 
-  def test_to_complex(self):
+  def testToComplex(self):
     tensor = tf.random.normal([1, 10, 4])
     mtf_shape = [mtf.Dimension(f'dim_{i}', s) for i, s in enumerate(tensor.shape)]
     tensor_mesh = mtf.import_tf_tensor(self.mesh, tensor, shape=mtf_shape)
@@ -646,7 +646,7 @@ class ComplexManipulationTest(tf.test.TestCase):
       tf.complex(tensor[..., 0:2], tensor[..., 2:4]),
     )
 
-  def test_split_complex(self):
+  def testSplitComplex(self):
     tensor = tf.complex(
       tf.random.normal([1, 10, 2]),
       tf.random.normal([1, 10, 2]),

--- a/mesh_tensorflow/ops_test.py
+++ b/mesh_tensorflow/ops_test.py
@@ -622,6 +622,51 @@ class RecomputeGradTest(tf.test.TestCase):
                         self.evaluate(expected_dx))
 
 
+class ComplexManipulationTest(tf.test.TestCase):
+  def setUP(self):
+    super(ComplexManipulationTest, self).setUp()
+    self.graph = mtf.Graph()
+    self.mesh = mtf.Mesh(self.graph, "my_mesh")
+
+  def test_to_complex(self):
+    tensor = tf.random.normal([1, 10, 4])
+    mtf_shape = [mtf.Dimension(f'dim_{i}', s) for i, s in enumerate(tensor.shape)]
+    tensor_mesh = mtf.import_tf_tensor(self.mesh, tensor, shape=mtf_shape)
+    outputs = mtf.to_complex(tensor_mesh)
+    assert outputs.dtype == tf.complex64
+    assert len(outputs.shape) == 3
+    assert outputs.shape[-1].size == 2
+    assert [s.size for s in outputs.shape[:-1]] == [s.size for s in tensor_mesh.shape[:-1]]
+    mesh_impl = mtf.placement_mesh_impl.PlacementMeshImpl(
+      shape=[], layout={}, devices=[""])
+    lowering = mtf.Lowering(self.graph, {self.mesh: mesh_impl})
+    outputs_tf = lowering.export_to_tf_tensor(outputs)
+    self.assertAllEqual(
+      outputs_tf,
+      tf.complex(tensor[..., 0:2], tensor[..., 2:4]),
+    )
+
+  def test_split_complex(self):
+    tensor = tf.complex(
+      tf.random.normal([1, 10, 2]),
+      tf.random.normal([1, 10, 2]),
+    )
+    mtf_shape = [mtf.Dimension(f'dim_{i}', s) for i, s in enumerate(tensor.shape)]
+    tensor_mesh = mtf.import_tf_tensor(self.mesh, tensor, shape=mtf_shape)
+    outputs = mtf.split_complex(tensor_mesh)
+    assert outputs.dtype == tf.float32
+    assert len(outputs.shape) == 3
+    assert outputs.shape[-1].size == 4
+    assert [s.size for s in outputs.shape[:-1]] == [s.size for s in tensor_mesh.shape[:-1]]
+    mesh_impl = mtf.placement_mesh_impl.PlacementMeshImpl(
+        shape=[], layout={}, devices=[""])
+    lowering = mtf.Lowering(self.graph, {self.mesh: mesh_impl})
+    outputs_tf = lowering.export_to_tf_tensor(outputs)
+    self.assertAllEqual(
+        outputs_tf,
+        tf.concat([tf.math.real(tensor), tf.math.imag(tensor)], axis=-1),
+    )
+
 if __name__ == "__main__":
   tf.disable_v2_behavior()
   tf.enable_eager_execution()

--- a/mesh_tensorflow/signal_ops.py
+++ b/mesh_tensorflow/signal_ops.py
@@ -10,7 +10,7 @@ import tensorflow.compat.v1 as tf
 from mesh_tensorflow import ops_with_redefined_builtins as mtf
 
 
-class FFTBaseOperation(mtf.Operation):
+class FFT3DBaseOperation(mtf.Operation):
   def __init__(self, inputs, dims, inverse=False, name=None):
     self.inverse = inverse
     if self.inverse:
@@ -67,7 +67,7 @@ class FFTBaseOperation(mtf.Operation):
       raise NotImplementedError('This function needs to be implemented')
 
 
-class FFT3DOperation(FFTBaseOperation):
+class FFT3DOperation(FFT3DBaseOperation):
   """
   Computes the 3-dimensional discrete Fourier transform over the inner-most 3
   dimensions of input tensor. Note that the output FFT is transposed.
@@ -112,7 +112,7 @@ def fft3d(x, freq_dims, name=None):
   """
   return FFT3DOperation(x, freq_dims, name).outputs[0]
 
-class iFFT3DOperation(FFTBaseOperation):
+class iFFT3DOperation(FFT3DBaseOperation):
   """
   Computes the inverse 3-dimensional discrete Fourier transform over the inner-most 3
   dimensions of input tensor. Note that the input FFT is assumed transposed.

--- a/mesh_tensorflow/signal_ops.py
+++ b/mesh_tensorflow/signal_ops.py
@@ -25,8 +25,8 @@ class FFTBaseOperation(mtf.Operation):
       dims_reordered = dims
     else:
       dims_reordered = [dims[1], dims[2], dims[0]]
-      self._output_shape = mtf.Shape(inputs.shape[:-3]+dims_reordered)
-      self._outputs = [mtf.Tensor(self, mtf.Shape(self._output_shape), inputs.dtype)]
+    self._output_shape = mtf.Shape(inputs.shape[:-3]+dims_reordered)
+    self._outputs = [mtf.Tensor(self, mtf.Shape(self._output_shape), inputs.dtype)]
 
   def gradient(self, grad_ys):
     dy = grad_ys[0]
@@ -112,7 +112,7 @@ def fft3d(x, freq_dims, name=None):
   """
   return FFT3DOperation(x, freq_dims, name).outputs[0]
 
-class iFFT3DOperation(mtf.Operation):
+class iFFT3DOperation(FFTBaseOperation):
   """
   Computes the inverse 3-dimensional discrete Fourier transform over the inner-most 3
   dimensions of input tensor. Note that the input FFT is assumed transposed.
@@ -125,46 +125,20 @@ class iFFT3DOperation(mtf.Operation):
   Returns:
     A Tensor of shape `input.shape[:-3] + dims`.
   """
-  def __init__(self, input,  dims, name=None):
-    super(iFFT3DOperation, self).__init__([input], name=name or "iFFT3D")
-    self._dims = dims
-    self._output_shape = mtf.Shape(input.shape[:-3]+dims)
-    self._outputs = [mtf.Tensor(self, mtf.Shape(self._output_shape), input.dtype)]
+  def __init__(self, inputs,  dims, name=None):
+    super(iFFT3DOperation, self).__init__(inputs, dims, inverse=True, name=name)
 
-  def gradient(self, grad_ys):
-    dy = grad_ys[0]
-    ky, kz, kx = self.inputs[0].shape[-3:]
-    return [fft3d(dy, [kx, ky, kz])]
+  def _make_sure_contiguous(self, mesh_impl, split_axes, slices, naxes):
+    if split_axes[0] is not None:
+      slices = mesh_impl.alltoall(slices, split_axes[0],  naxes-1,  naxes-3)
+      split_axes[-1] = split_axes[0]
+      split_axes[0] = None
+    perm = np.arange(naxes)
+    perm[-3:] = np.roll(perm[-3:], shift=-1)
+    slices = mesh_impl.slicewise(lambda x: tf.transpose(x, perm), slices)
+    split_axes = [split_axes[1], split_axes[2], split_axes[0]]
+    return split_axes, slices
 
-  def lower(self, lowering):
-    mesh_impl = lowering.mesh_impl(self)
-    x = self.inputs[0]
-    naxes = len(x.shape)
-    slices = lowering.tensors[self.inputs[0]]
-    # Before performing any operations, we check the splitting
-    split_axes = []
-    for i in range(3):
-        split_axes.append(mesh_impl.tensor_dimension_to_mesh_axis(x.shape.dims[-3:][i]))
-
-    # Perform FFT followed by tranposes
-    for i in range(2):
-        # Apply FFT along last axis
-        slices = mesh_impl.slicewise(tf.spectral.ifft, slices)
-
-        # Before transposing the array, making sure the new last dimension will
-        # be contiguous
-        if split_axes[0] is not None:
-            slices = mesh_impl.alltoall(slices, split_axes[0],  naxes-1,  naxes-3)
-            split_axes[-1] = split_axes[0]
-            split_axes[0] = None
-        perm = np.arange(len(x.shape))
-        perm[-3:] = np.roll(perm[-3:], shift=-1)
-        slices = mesh_impl.slicewise(lambda x: tf.transpose(x, perm), slices)
-        split_axes = [split_axes[1], split_axes[2], split_axes[0]]
-
-    # Apply FFT along last axis
-    slices = mesh_impl.slicewise(tf.spectral.ifft, slices)
-    lowering.set_tensor_lowering(self.outputs[0], slices)
 
 def ifft3d(x, dims, name=None):
   """

--- a/mesh_tensorflow/signal_ops.py
+++ b/mesh_tensorflow/signal_ops.py
@@ -45,21 +45,21 @@ class FFTBaseOperation(mtf.Operation):
       # Before performing any operations, we check the splitting
       split_axes = []
       for i in range(3):
-          split_axes.append(mesh_impl.tensor_dimension_to_mesh_axis(x.shape.dims[-3:][i]))
+        split_axes.append(mesh_impl.tensor_dimension_to_mesh_axis(x.shape.dims[-3:][i]))
 
       # Perform transform followed by tranposes
       for i in range(2):
-          # Apply FFT along last axis
-          slices = mesh_impl.slicewise(self.tf_op, slices)
+        # Apply FFT along last axis
+        slices = mesh_impl.slicewise(self.tf_op, slices)
 
-          # Before transposing the array, making sure the new last dimension will
-          # be contiguous
-          split_axes, slices = self._make_sure_contiguous(
-            mesh_impl,
-            split_axes,
-            slices,
-            naxes,
-          )
+        # Before transposing the array, making sure the new last dimension will
+        # be contiguous
+        split_axes, slices = self._make_sure_contiguous(
+          mesh_impl,
+          split_axes,
+          slices,
+          naxes,
+        )
 
       # Apply transform along last axis
       slices = mesh_impl.slicewise(self.tf_op, slices)
@@ -80,7 +80,7 @@ class FFT3DOperation(FFTBaseOperation):
     name: A name for the operation (optional).
 
   Returns:
-    A Tensor of shape `input.shape[:-3] + freq_dims`.
+    A Tensor of shape `input.shape[:-3] + freq_dims[1] + freq_dims[2] + freq_dims[0]`.
   """
   def __init__(self, inputs,  dims, name=None):
     super(FFT3DOperation, self).__init__(inputs, dims, inverse=False, name=name)

--- a/mesh_tensorflow/signal_ops.py
+++ b/mesh_tensorflow/signal_ops.py
@@ -19,7 +19,7 @@ class FFT3DBaseOperation(mtf.Operation):
     else:
       self.default_name = 'FFT3D'
       self.tf_op = tf.spectral.fft
-    super(FFTBaseOperation, self).__init__([inputs], name=name or self.default_name)
+    super(FFT3DBaseOperation, self).__init__([inputs], name=name or self.default_name)
     self._dims = dims
     if self.inverse:
       dims_reordered = dims

--- a/mesh_tensorflow/signal_ops.py
+++ b/mesh_tensorflow/signal_ops.py
@@ -87,7 +87,7 @@ class FFT3DBaseOperation(mtf.Operation):
         split_axes = [split_axes[2], split_axes[0], split_axes[1]]
 
     perm = np.arange(naxes)
-    perm[-3:] = np.roll(perm[-3:], shift=-1)
+    perm[-3:] = np.roll(perm[-3:], shift=-1 if self.inverse else 1)
     slices = mesh_impl.slicewise(lambda x: tf.transpose(x, perm), slices)
     return split_axes, slices
 
@@ -119,4 +119,4 @@ def ifft3d(x, dims, name=None):
   Returns:
     A Tensor of shape `input.shape[:-3] + dims`.
   """
-  return FFT3DBaseOperation(x, freq_dims, inverse=True, name=name).outputs[0]
+  return FFT3DBaseOperation(x, dims, inverse=True, name=name).outputs[0]

--- a/mesh_tensorflow/signal_ops.py
+++ b/mesh_tensorflow/signal_ops.py
@@ -3,21 +3,12 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import collections
-import functools
-import itertools
-import operator
-import os
-import re
-
-from mesh_tensorflow import utils
 import numpy as np
-import six
-from six.moves import xrange  # pylint: disable=redefined-builtin
 
 import tensorflow.compat.v1 as tf
 
 from mesh_tensorflow import ops_with_redefined_builtins as mtf
+
 
 class FFT3DOperation(mtf.Operation):
   """

--- a/mesh_tensorflow/signal_ops.py
+++ b/mesh_tensorflow/signal_ops.py
@@ -10,7 +10,66 @@ import tensorflow.compat.v1 as tf
 from mesh_tensorflow import ops_with_redefined_builtins as mtf
 
 
-class FFT3DOperation(mtf.Operation):
+class FFTBaseOperation(mtf.Operation):
+  def __init__(self, inputs, dims, inverse=False, name=None):
+    self.inverse = inverse
+    if self.inverse:
+      self.default_name = 'IFFT3D'
+      self.tf_op = tf.spectral.ifft
+    else:
+      self.default_name = 'FFT3D'
+      self.tf_op = tf.spectral.fft
+    super(FFTBaseOperation, self).__init__([inputs], name=name or self.default_name)
+    self._dims = dims
+    if self.inverse:
+      dims_reordered = dims
+    else:
+      dims_reordered = [dims[1], dims[2], dims[0]]
+      self._output_shape = mtf.Shape(inputs.shape[:-3]+dims_reordered)
+      self._outputs = [mtf.Tensor(self, mtf.Shape(self._output_shape), inputs.dtype)]
+
+  def gradient(self, grad_ys):
+    dy = grad_ys[0]
+    if self.inverse:
+      ky, kz, kx = self.inputs[0].shape[-3:]
+      return [fft3d(dy, [kx, ky, kz])]
+    else:
+      x = self.inputs[0]
+      return [ifft3d(dy, x.shape[-3:])]
+
+  def lower(self, lowering):
+      mesh_impl = lowering.mesh_impl(self)
+      x = self.inputs[0]
+      naxes = len(x.shape)
+      slices = lowering.tensors[self.inputs[0]]
+      # Before performing any operations, we check the splitting
+      split_axes = []
+      for i in range(3):
+          split_axes.append(mesh_impl.tensor_dimension_to_mesh_axis(x.shape.dims[-3:][i]))
+
+      # Perform transform followed by tranposes
+      for i in range(2):
+          # Apply FFT along last axis
+          slices = mesh_impl.slicewise(self.tf_op, slices)
+
+          # Before transposing the array, making sure the new last dimension will
+          # be contiguous
+          split_axes, slices = self._make_sure_contiguous(
+            mesh_impl,
+            split_axes,
+            slices,
+            naxes,
+          )
+
+      # Apply transform along last axis
+      slices = mesh_impl.slicewise(self.tf_op, slices)
+      lowering.set_tensor_lowering(self.outputs[0], slices)
+
+  def _make_sure_contiguous(self, *args):
+      raise NotImplementedError('This function needs to be implemented')
+
+
+class FFT3DOperation(FFTBaseOperation):
   """
   Computes the 3-dimensional discrete Fourier transform over the inner-most 3
   dimensions of input tensor. Note that the output FFT is transposed.
@@ -23,46 +82,20 @@ class FFT3DOperation(mtf.Operation):
   Returns:
     A Tensor of shape `input.shape[:-3] + freq_dims`.
   """
-  def __init__(self, input,  freq_dims, name=None):
-    super(FFT3DOperation, self).__init__([input], name=name or "FFT3D")
-    self._freq_dims = freq_dims
-    self._output_shape = mtf.Shape(input.shape[:-3]+[freq_dims[1], freq_dims[2], freq_dims[0]])
-    self._outputs = [mtf.Tensor(self, mtf.Shape(self._output_shape), input.dtype)]
+  def __init__(self, inputs,  dims, name=None):
+    super(FFT3DOperation, self).__init__(inputs, dims, inverse=False, name=name)
 
-  def gradient(self, grad_ys):
-    dy = grad_ys[0]
-    x = self.inputs[0]
-    return [ifft3d(dy, x.shape[-3:])]
+  def _make_sure_contiguous(self, mesh_impl, split_axes, slices, naxes):
+      if split_axes[-2] is not None:
+          slices = mesh_impl.alltoall(slices, split_axes[-2],  naxes-1,  naxes-2)
+          split_axes[-1] = split_axes[-2]
+          split_axes[-2] = None
+      perm = np.arange(naxes)
+      perm[-3:] = np.roll(perm[-3:], shift=1)
+      slices = mesh_impl.slicewise(lambda x: tf.transpose(x, perm), slices)
+      split_axes = [split_axes[2], split_axes[0], split_axes[1]]
+      return split_axes, slices
 
-  def lower(self, lowering):
-    mesh_impl = lowering.mesh_impl(self)
-    x = self.inputs[0]
-    naxes = len(x.shape)
-    slices = lowering.tensors[self.inputs[0]]
-    # Before performing any operations, we check the splitting
-    split_axes = []
-    for i in range(3):
-        split_axes.append(mesh_impl.tensor_dimension_to_mesh_axis(x.shape.dims[-3:][i]))
-
-    # Perform FFT followed by tranposes
-    for i in range(2):
-        # Apply FFT along last axis
-        slices = mesh_impl.slicewise(tf.spectral.fft, slices)
-
-        # Before transposing the array, making sure the new last dimension will
-        # be contiguous
-        if split_axes[-2] is not None:
-            slices = mesh_impl.alltoall(slices, split_axes[-2],  naxes-1,  naxes-2)
-            split_axes[-1] = split_axes[-2]
-            split_axes[-2] = None
-        perm = np.arange(len(x.shape))
-        perm[-3:] = np.roll(perm[-3:], shift=1)
-        slices = mesh_impl.slicewise(lambda x: tf.transpose(x, perm), slices)
-        split_axes = [split_axes[2], split_axes[0], split_axes[1]]
-
-    # Apply FFT along last axis
-    slices = mesh_impl.slicewise(tf.spectral.fft, slices)
-    lowering.set_tensor_lowering(self.outputs[0], slices)
 
 def fft3d(x, freq_dims, name=None):
   """

--- a/mesh_tensorflow/signal_ops.py
+++ b/mesh_tensorflow/signal_ops.py
@@ -108,7 +108,7 @@ def fft3d(x, freq_dims, name=None):
     name: A name for the operation (optional).
 
   Returns:
-    A Tensor of shape `input.shape[:-3] + freq_dims`.
+    A Tensor of shape `input.shape[:-3] + freq_dims[1] + freq_dims[2] + freq_dims[0]`.
   """
   return FFT3DOperation(x, freq_dims, name).outputs[0]
 

--- a/mesh_tensorflow/signal_ops_test.py
+++ b/mesh_tensorflow/signal_ops_test.py
@@ -15,7 +15,10 @@ class FFTTest(tf.test.TestCase):
     cols_dim = mtf.Dimension("cols", volume_size)
     self.shape = [batch_dim, slices_dim, rows_dim, cols_dim,]
     volume_shape = [d.size for d in self.shape]
-    self.volume = tf.random.normal(volume_shape)
+    self.volume = tf.complex(
+        tf.random.normal(volume_shape),
+        tf.random.normal(volume_shape),
+    )
     self.volume_mesh = mtf.import_tf_tensor(self.mesh, self.volume, shape=self.shape)
 
 
@@ -23,30 +26,40 @@ class FFTTest(tf.test.TestCase):
     outputs = fft3d(self.volume_mesh, freq_dims=self.shape[1:4])
     assert len(outputs.shape) == 4
     assert outputs.dtype == tf.complex64
-    assert outputs.shape == self.shape
+    # assert outputs.shape == mtf.Shape(self.shape)
+    assert [d.size for d in outputs.shape] == [d.size for d in self.shape]
     mesh_impl = mtf.placement_mesh_impl.PlacementMeshImpl(
       shape=[], layout={}, devices=[""])
     lowering = mtf.Lowering(self.graph, {self.mesh: mesh_impl})
     outputs_tf = lowering.export_to_tf_tensor(outputs)
-    tf_tester = tf.test.TestCase()
     expected_outputs = tf.signal.fft3d(self.volume)
-    tf_tester.assertAllEqual(
+    expected_outputs = tf.transpose(expected_outputs, perm=[0, 2, 3, 1])
+    self.assertAllClose(
       outputs_tf,
       expected_outputs,
+      rtol=1e-4,
+      atol=1e-4,
     )
 
   def testIfft3d(self):
-    outputs = ifft3d(self.volume_mesh, dims=self.shape[1:4])
+    outputs = ifft3d(
+        self.volume_mesh,
+        # ordering is not the same for ifft3d
+        dims=[self.shape[3], self.shape[1], self.shape[2]],
+    )
     assert len(outputs.shape) == 4
     assert outputs.dtype == tf.complex64
-    assert outputs.shape == self.shape
+    # assert outputs.shape == mtf.Shape(self.shape)
+    assert [d.size for d in outputs.shape] == [d.size for d in self.shape]
     mesh_impl = mtf.placement_mesh_impl.PlacementMeshImpl(
       shape=[], layout={}, devices=[""])
     lowering = mtf.Lowering(self.graph, {self.mesh: mesh_impl})
     outputs_tf = lowering.export_to_tf_tensor(outputs)
-    tf_tester = tf.test.TestCase()
     expected_outputs = tf.signal.ifft3d(self.volume)
-    tf_tester.assertAllEqual(
+    expected_outputs = tf.transpose(expected_outputs, perm=[0, 3, 1, 2])
+    self.assertAllClose(
       outputs_tf,
       expected_outputs,
+      rtol=1e-4,
+      atol=1e-4,
     )

--- a/mesh_tensorflow/signal_ops_test.py
+++ b/mesh_tensorflow/signal_ops_test.py
@@ -10,11 +10,10 @@ class FFTTest(tf.test.TestCase):
     self.mesh = mtf.Mesh(self.graph, "my_mesh")
     volume_size = 32
     batch_dim = mtf.Dimension("batch", 1)
-    cols_dim = mtf.Dimension("cols", volume_size)
-    volume_channels_dim = mtf.Dimension('channels', 1)
     slices_dim = mtf.Dimension("slices", volume_size)
     rows_dim = mtf.Dimension("rows", volume_size)
-    self.shape = [batch_dim, slices_dim, rows_dim, cols_dim, volume_channels_dim]
+    cols_dim = mtf.Dimension("cols", volume_size)
+    self.shape = [batch_dim, slices_dim, rows_dim, cols_dim,]
     volume_shape = [d.size for d in self.shape]
     self.volume = tf.random.normal(volume_shape)
     self.volume_mesh = mtf.import_tf_tensor(self.mesh, self.volume, shape=self.shape)

--- a/mesh_tensorflow/signal_ops_test.py
+++ b/mesh_tensorflow/signal_ops_test.py
@@ -1,0 +1,53 @@
+import mesh_tensorflow as mtf
+from mesh_tensorflow.signal_ops import fft3d, ifft3d
+import tensorflow as tf
+
+
+class FFTTest(tf.test.TestCase):
+  def setUp(self):
+    super(FFTTest, self).setUp()
+    self.graph = mtf.Graph()
+    self.mesh = mtf.Mesh(self.graph, "my_mesh")
+    volume_size = 32
+    batch_dim = mtf.Dimension("batch", 1)
+    cols_dim = mtf.Dimension("cols", volume_size)
+    volume_channels_dim = mtf.Dimension('channels', 1)
+    slices_dim = mtf.Dimension("slices", volume_size)
+    rows_dim = mtf.Dimension("rows", volume_size)
+    self.shape = [batch_dim, slices_dim, rows_dim, cols_dim, volume_channels_dim]
+    volume_shape = [d.size for d in self.shape]
+    self.volume = tf.random.normal(volume_shape)
+    self.volume_mesh = mtf.import_tf_tensor(self.mesh, self.volume, shape=self.shape)
+
+
+  def testFft3d(self):
+    outputs = fft3d(self.volume_mesh, freq_dims=self.shape[1:4])
+    assert len(outputs.shape) == 4
+    assert outputs.dtype == tf.complex64
+    assert outputs.shape == self.shape
+    mesh_impl = mtf.placement_mesh_impl.PlacementMeshImpl(
+      shape=[], layout={}, devices=[""])
+    lowering = mtf.Lowering(self.graph, {self.mesh: mesh_impl})
+    outputs_tf = lowering.export_to_tf_tensor(outputs)
+    tf_tester = tf.test.TestCase()
+    expected_outputs = tf.signal.fft3d(self.volume)
+    tf_tester.assertAllEqual(
+      outputs_tf,
+      expected_outputs,
+    )
+
+  def testIfft3d(self):
+    outputs = ifft3d(self.volume_mesh, dims=self.shape[1:4])
+    assert len(outputs.shape) == 4
+    assert outputs.dtype == tf.complex64
+    assert outputs.shape == self.shape
+    mesh_impl = mtf.placement_mesh_impl.PlacementMeshImpl(
+      shape=[], layout={}, devices=[""])
+    lowering = mtf.Lowering(self.graph, {self.mesh: mesh_impl})
+    outputs_tf = lowering.export_to_tf_tensor(outputs)
+    tf_tester = tf.test.TestCase()
+    expected_outputs = tf.signal.ifft3d(self.volume)
+    tf_tester.assertAllEqual(
+      outputs_tf,
+      expected_outputs,
+    )

--- a/mesh_tensorflow/signal_ops_test.py
+++ b/mesh_tensorflow/signal_ops_test.py
@@ -10,7 +10,7 @@ class FFTTest(tf.test.TestCase):
     self.mesh = mtf.Mesh(self.graph, "my_mesh")
     volume_size = 32
     batch_dim = mtf.Dimension("batch", 1)
-    slices_dim = mtf.Dimension("slices", volume_size)
+    slices_dim = mtf.Dimension("slices", volume_size//2)
     rows_dim = mtf.Dimension("rows", volume_size)
     cols_dim = mtf.Dimension("cols", volume_size)
     self.shape = [batch_dim, slices_dim, rows_dim, cols_dim,]
@@ -26,8 +26,7 @@ class FFTTest(tf.test.TestCase):
     outputs = fft3d(self.volume_mesh, freq_dims=self.shape[1:4])
     assert len(outputs.shape) == 4
     assert outputs.dtype == tf.complex64
-    # assert outputs.shape == mtf.Shape(self.shape)
-    assert [d.size for d in outputs.shape] == [d.size for d in self.shape]
+    assert set(outputs.shape) == set(mtf.Shape(self.shape))
     mesh_impl = mtf.placement_mesh_impl.PlacementMeshImpl(
       shape=[], layout={}, devices=[""])
     lowering = mtf.Lowering(self.graph, {self.mesh: mesh_impl})
@@ -49,8 +48,7 @@ class FFTTest(tf.test.TestCase):
     )
     assert len(outputs.shape) == 4
     assert outputs.dtype == tf.complex64
-    # assert outputs.shape == mtf.Shape(self.shape)
-    assert [d.size for d in outputs.shape] == [d.size for d in self.shape]
+    assert set(outputs.shape) == set(mtf.Shape(self.shape))
     mesh_impl = mtf.placement_mesh_impl.PlacementMeshImpl(
       shape=[], layout={}, devices=[""])
     lowering = mtf.Lowering(self.graph, {self.mesh: mesh_impl})

--- a/mesh_tensorflow/signal_ops_test.py
+++ b/mesh_tensorflow/signal_ops_test.py
@@ -53,8 +53,8 @@ class FFTTest(tf.test.TestCase):
       shape=[], layout={}, devices=[""])
     lowering = mtf.Lowering(self.graph, {self.mesh: mesh_impl})
     outputs_tf = lowering.export_to_tf_tensor(outputs)
-    expected_outputs = tf.signal.ifft3d(self.volume)
-    expected_outputs = tf.transpose(expected_outputs, perm=[0, 3, 1, 2])
+    volume = tf.transpose(self.volume, perm=[0, 3, 1, 2])
+    expected_outputs = tf.signal.ifft3d(volume)
     self.assertAllClose(
       outputs_tf,
       expected_outputs,


### PR DESCRIPTION
This PR adds:
- complex manipulation ops (going from and to complex-valued tensors)
- tests for complex manipulation ops
- tests for signal ops (`fft3d` and `ifft3d`)

The tests are passing in the current state, but I am going to suggest in a comment underneath some modifications to the current code.